### PR TITLE
Shrink the nav-menu to right

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -205,12 +205,12 @@ h6 {
 }
 
 .mobile-nav {
-  width: 220px;
+  width: 220px;     /*Include width attribute to shrink the menu.*/
   position: fixed;
   top: 55px;
   right: 15px;
+  /*Remove left margin to align right.*/
   bottom: 15px;
-  left: 15px;
   z-index: 9999;
   overflow-y: auto;
   background: #fff;
@@ -218,7 +218,7 @@ h6 {
   opacity: 0;
   visibility: hidden;
   border-radius: 10px;
-  padding: 10px 0 0 10px;
+  padding: 10px 0 0 10px; /*Add padding-left for good indent.*/
 }
 
 .mobile-nav * {

--- a/static/style.css
+++ b/static/style.css
@@ -205,6 +205,7 @@ h6 {
 }
 
 .mobile-nav {
+  width: 220px;
   position: fixed;
   top: 55px;
   right: 15px;
@@ -217,7 +218,7 @@ h6 {
   opacity: 0;
   visibility: hidden;
   border-radius: 10px;
-  padding: 10px 0;
+  padding: 10px 0 0 10px;
 }
 
 .mobile-nav * {

--- a/static/style.css
+++ b/static/style.css
@@ -210,8 +210,6 @@ h6 {
   position: fixed;
   top: 55px;
   right: 15px;
-  /*Remove left margin to align right.*/
-  /*remove bottom margin to reduce height.*/
   z-index: 9999;
   overflow-y: auto;
   background: #fff;
@@ -886,9 +884,7 @@ span.scale-rating label:before {
   vertical-align: middle;
   z-index: 2;
 }
- master
-
-
+ 
 
 #preloader {
   position: fixed;
@@ -906,4 +902,4 @@ span.scale-rating label:before {
 #status {
   position: relative;
 }
- master
+


### PR DESCRIPTION
## Related Issuse

- Info about Issue or bug

Closes: #83 

#### Describe the changes you've made

Change the width of the nav-menu to align with the navigation icon at the top right corner. Also, add some indent to the menu elements.
## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
| **
![2021-03-11 (2)_LI](https://user-images.githubusercontent.com/79015142/111172596-f75f3800-85cb-11eb-9ee8-e8fe8a075120.jpg)
** | <b> 
![Screenshot 2021-03-15 20 08 37](https://user-images.githubusercontent.com/79015142/111172303-b6ffba00-85cb-11eb-8a78-aec984ebb358.png)
</b> |
