### PR TITLE
Gsoc'21 fix the responsiveness of preloader and copyright section in footer in mobile version

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -898,6 +898,7 @@ span.scale-rating label:before {
   background-position: center;
   background-color: rgb(255, 255, 255);
   z-index: 9999;
+  background-size: contain;
 }
 
 #status {

--- a/templates/base.html
+++ b/templates/base.html
@@ -164,10 +164,12 @@
         </div>
       </div>
 
-      <div class="container">
+      <div class="container px-0">
         <div class="copyright">
+          <p>
           Made with ❤️️ by <strong><a
               href="https://linktr.ee/akshatkhanna" style="color: #25B0F0;">Akshat Khanna</a> & <a href="https://linktr.ee/Ping_Unnati" style="color: #25B0F0;">Unnati Mishra</a></strong>.
+          </p>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## Related Issuse

Preloader was not responsive in mobile version so i fix it and copy right section was also not looking good
<img width="960" alt="latprob" src="https://user-images.githubusercontent.com/55352601/111870487-0e769f00-89ab-11eb-9304-0ad1f28fdd26.png">


Closes: #[109]

#### Describe the changes you've made
It is now looking like this
<img width="960" alt="s1" src="https://user-images.githubusercontent.com/55352601/111870435-be97d800-89aa-11eb-9689-64fd2f1167e0.png">

<img width="960" alt="latsol" src="https://user-images.githubusercontent.com/55352601/111870493-159dad00-89ab-11eb-9829-1b2e01270044.png">


## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [ x] My code follows the style guidelines of this project.
- [x ] I have performed a self-review of my own code.
- [x ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ x] My changes generate no new warnings.

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
| **original screenshot** | <b>updated screenshot </b> |
