### PR TITLE
fix the responsiveness of preloader and copyright section in footer

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -898,6 +898,7 @@ span.scale-rating label:before {
   background-position: center;
   background-color: rgb(255, 255, 255);
   z-index: 9999;
+  background-size: contain;
 }
 
 #status {

--- a/templates/base.html
+++ b/templates/base.html
@@ -164,10 +164,12 @@
         </div>
       </div>
 
-      <div class="container">
+      <div class="container px-0">
         <div class="copyright">
+          <p>
           Made with ❤️️ by <strong><a
               href="https://linktr.ee/akshatkhanna" style="color: #25B0F0;">Akshat Khanna</a> & <a href="https://linktr.ee/Ping_Unnati" style="color: #25B0F0;">Unnati Mishra</a></strong>.
+          </p>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## Related Issuse

Preloader  and footer is not responsive in small screen It was not looking so good.
It was looking like this
<img width="960" alt="p5" src="https://user-images.githubusercontent.com/55352601/112027201-f9417200-8b5c-11eb-9a55-dfcb78393db5.png">
 

Closes: #109 

#### Describe the changes you've made
I had made preloader and copy-right section in footer responsive in all screen
now it is looing like this. I hope you will like this.


https://user-images.githubusercontent.com/55352601/112027591-52a9a100-8b5d-11eb-9795-d444e8f52f37.mp4


## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
| **original screenshot** | <b>updated screenshot </b> |
