### PR TITLE
Changed Forgot Password to Login side

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -82,7 +82,6 @@
                                   <input type="password" name="rpassword" class="form-control" placeholder="Confirm Password" id="exampleInputRPassword1" required>
                                   {{errorPC}}
                                 </div>
-                                <i class="ion-ios-arrow-right"></i> <a href="{% url 'forgotp' %}">Forget Password</a>
                                 <button type="submit" class="btn btn-primary">Submit</button>  
                               </form>
                         </div>
@@ -99,6 +98,7 @@
                                   <input type="password" name="password" class="form-control" placeholder="Password" id="exampleInputPassword1">
                                     {{invalid}}
                                 </div>
+                                <i class="ion-ios-arrow-right"></i> <a href="{% url 'forgotp' %}">Forgot Password</a>
                                 <button type="submit" class="btn btn-primary">Submit</button>
                               </form>
                               <!-- social login buttons -->


### PR DESCRIPTION
## Related Issues

- Typo in Login/Signup Page, **Forget** instead of Forgot Password
- Logical Error: Forgot Password link should be placed in the **login** side.

**Closes:** #127 

#### Describe the changes you've made

- Changed Forget password to **Forgot** password
- placed the corrected link in Login side in the page.

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
| ![image](https://user-images.githubusercontent.com/61737202/113003377-4c847780-9190-11eb-8395-193f0bf94e2d.png)| ![image](https://user-images.githubusercontent.com/61737202/113003609-848bba80-9190-11eb-968f-09ad73587c2c.png)|
