### PR TITLE
password validations and exception handling

### DIFF
--- a/electricity/views.py
+++ b/electricity/views.py
@@ -23,11 +23,11 @@ def send_email_to_user(otp,email):
     con = smtplib.SMTP("smtp.gmail.com",587)
     con.ehlo()
     con.starttls()
-    admin_email = "your email"
+    admin_email = "email"
     admin_password = "password"
     con.login(admin_email,admin_password)
     msg = "Otp is "+str(otp)
-    con.sendmail("your email",email,"Subject:Password Reset \n\n"+msg)
+    con.sendmail("email",email,"Subject:Password Reset \n\n"+msg)
 
 
 def index(request):
@@ -101,7 +101,7 @@ def loginuser(request):
         else:
             return render(request, 'login.html')
 
-global_dict = {'otp':"",'email':""}          
+global_dict = {'otp':"",'email':"",'otpcheck':""}          
 def generate_otp():
     digits = [i for i in range(0, 10)]
     random_str = ""
@@ -135,6 +135,7 @@ def otp(request):
         get_otp = request.POST["otp"]
         if global_dict['otp'] == get_otp:
             print("match")
+            global_dict['otpcheck'] = "1"
             return redirect('reset_password')
         else:
             print("otp is",global_dict['otp'])
@@ -145,13 +146,12 @@ def otp(request):
 
 def reset_password(request):
     if request.method == "POST":
-        print("post")
         password = request.POST["password"]
         rpassword = request.POST["rpassword"]
         if rpassword != password:
             messages.error(request, 'Password not Matched')
-        elif len(password)<=8:
-            messages.error(request,"Length must be greter then 8")
+        elif len(password)<=7:
+            messages.error(request,"Minimum 8 characters required")
         else:
             print("matched",global_dict['email'])
             user = User.objects.filter(email=global_dict['email']).first()
@@ -161,7 +161,17 @@ def reset_password(request):
             messages.success(request,"Password Reset Successfully! Please Login")
             return redirect("login")
     else:
-        print("get")
+        if global_dict['email'] == "":
+            messages.error(request,"Please Enter your email")
+            return redirect("forgotp")
+
+        if global_dict['otp'] == "":
+            messages.error(request,"Please Enter Otp first")
+            return redirect("otp")
+        if len(global_dict['otpcheck']) == 0:
+            messages.error(request,"Otp not found")
+            return redirect("otp")
+            
     return render(request,'resetpassword.html')
 
 def logoutuser(request):

--- a/templates/resetpassword.html
+++ b/templates/resetpassword.html
@@ -11,6 +11,65 @@ form
 {
     width: 100%;
 }
+/*css for errror area*/
+.errorarea1
+  {
+    display:none;
+      margin-top: 5px;
+  }
+  .errorarea2
+  {
+
+    display:none;
+      margin-top: 5px;
+  }
+  /* The message box is shown when the user clicks on the password field */
+  #message {
+    visibility:hidden;
+  }
+  
+  #message p {
+    padding: 0px 5px;
+    font-size: 11px;
+    margin-bottom: 0px;
+  }
+
+  #message2 {
+    visibility:hidden;
+  }
+  
+  #message2 p {
+    padding: 0px 5px;
+    font-size: 11px;
+    margin-bottom: 0px;
+  }
+  
+  /* Add a green text color and a checkmark when the requirements are right */
+  .valid {
+    color: green;
+  }
+  
+  .valid:before {
+    position: relative;
+    left: -3px;
+    content: "✔";
+  }
+  
+  /* Add a red text color and an "x" when the requirements are wrong */
+  .invalid {
+    color: red;
+  }
+  
+  .invalid:before {
+    position: relative;
+    left: -3px;
+    content: "✖";
+  }
+  .alert {
+    width:90%;
+    margin-left:6vw;
+    margin-top:1vh;
+  }
 </style>
 
 {% endblock style %}
@@ -42,12 +101,27 @@ form
                                 <h2>Enter Your Password</h2>
                 
                                 <div class="form-group">
-                                  <input type="password" name="password" class="form-control" placeholder="Password" id="exampleInputPassword1" required>
-                                </div>
-                                <div class="form-group">
-                                  <input type="password" name="rpassword" class="form-control" placeholder="Confirm Password" id="exampleInputRPassword1" required>
-                                  {{ErrorFP}}
-                                </div>
+                                    <input type="password" name="password" class="form-control" placeholder="Password" id="psw" pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}" placeholder="Password" title="Must contain at least one number and one uppercase and lowercase letter, and at least 8 or more characters" required>
+                                      <div class="errorarea1" id="errorarea1">
+                                        <div id="message" class="col col-11">
+                                          <p id="letter" class="invalid">A <b>lowercase</b> letter</p>
+                                          <p id="capital" class="invalid">A <b>capital (uppercase)</b> letter</p>
+                                          <p id="number" class="invalid">A <b>number</b></p>
+                                          <p id="length" class="invalid">Minimum <b>8 characters</b></p>
+                                        </div>
+                                      </div>
+                                    
+                                  </div>
+                                  <div class="form-group">
+                                    <input type="password" name="rpassword" class="form-control" placeholder="Confirm Password" id="psw2" pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}" title="Must contain at least one number and one uppercase and lowercase letter, and at least 8 or more characters" required>
+                                          <div class="errorarea2" id="errorarea2">
+                                          <div id="message2" class="col col-11">
+                                          <p id="passwordmatch" class="invalid"> <b>Password</b>Matched</p>
+                                      </div>
+                                          </div>
+                                
+                                  </div>
+                                  
                                 <button type="submit"  name="form_one" class="btn btn-primary">Submit</button>  
                               </form>
                         </div>
@@ -57,5 +131,106 @@ form
         </div>
 
     </div>
-
+    <script>
+        var myInput = document.getElementById("psw");
+    var myinput2 = document.getElementById("psw2");
+      var letter = document.getElementById("letter");
+      var capital = document.getElementById("capital");
+      var number = document.getElementById("number");
+      var length = document.getElementById("length");
+      var passwordmatch = document.getElementById("passwordmatch");
+      var errorarea1 = document.getElementById("errorarea1");
+      var errorarea2 = document.getElementById("errorarea2");
+    
+    
+      console.log(passwordmatch)
+      // When the user clicks on the password field, show the message box
+      myInput.onfocus = function() {
+        document.getElementById("message").style.visibility = "visible";
+        errorarea1.style.display = "block";
+      }
+      
+      // When the user clicks outside of the password field, hide the message box
+      myInput.onblur = function() {
+        document.getElementById("message").style.visibility = "hidden";
+        errorarea1.style.display = "none";
+      }
+    
+      
+    
+      // for confirm password
+      
+     // When the user clicks on the password field, show the message box
+     myinput2.onfocus = function() {
+      document.getElementById("message2").style.visibility = "visible";
+      errorarea2.style.display = "block";
+    }
+    
+    // When the user clicks outside of the password field, hide the message box
+    myinput2.onblur = function() {
+      document.getElementById("message2").style.visibility = "hidden";
+      errorarea1.style.display = "none";
+    }
+    
+      
+      // When the user starts to type something inside the password field
+      myInput.onkeyup = function() {
+    
+        // Validate lowercase letters
+        var lowerCaseLetters = /[a-z]/g;
+        if(myInput.value.match(lowerCaseLetters)) {  
+          letter.classList.remove("invalid");
+          letter.classList.add("valid");
+        } else {
+          letter.classList.remove("valid");
+          letter.classList.add("invalid");
+        }
+        
+        // Validate capital letters
+        var upperCaseLetters = /[A-Z]/g;
+        if(myInput.value.match(upperCaseLetters)) {  
+          capital.classList.remove("invalid");
+          capital.classList.add("valid");
+        } else {
+          capital.classList.remove("valid");
+          capital.classList.add("invalid");
+        }
+      
+        // Validate numbers
+        var numbers = /[0-9]/g;
+        if(myInput.value.match(numbers)) {  
+          number.classList.remove("invalid");
+          number.classList.add("valid");
+        } else {
+          number.classList.remove("valid");
+          number.classList.add("invalid");
+        }
+        
+        // Validate length
+        if(myInput.value.length >= 8) {
+          length.classList.remove("invalid");
+          length.classList.add("valid");
+        } else {
+          length.classList.remove("valid");
+          length.classList.add("invalid");
+        }
+      }
+    
+      myinput2.onkeyup = function() {
+      
+        // validating confirm password
+        if (myInput.value == myinput2.value)
+        {
+            passwordmatch.classList.remove("invalid");
+            passwordmatch.classList.add("valid");
+    
+        }
+        else
+        {
+            passwordmatch.classList.remove("valid");
+            passwordmatch.classList.add("invalid");
+        }
+      
+      }
+    </script>
 {% endblock %} 


### PR DESCRIPTION
## Related Issuse

Bug and enhancements in reset password features
Add all password validations as we have in sign up form
When the user moves to url '/reset-password' pl. check if he has passed the OTP verification or not. (I just added an email in forget email and went to localhost/reset-password without entering OTP then changed the password and it was changed).
Some typos in the error messages.

Closes: #198 

#### Describe the changes you've made


https://user-images.githubusercontent.com/55352601/118826621-4598fc00-b8d9-11eb-8859-6a06b29e216d.mp4



## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
| **original screenshot** | <b>updated screenshot </b> |
